### PR TITLE
FIx rot_def set_rotation doesn't raise exception when rot has invalid…

### DIFF
--- a/grplot/features/rot/rot_def.py
+++ b/grplot/features/rot/rot_def.py
@@ -1,15 +1,15 @@
 def rot_def(ax, axis, rot):
     if axis == 'x':
-        try:
+        if (type(rot) == int) or (rot in ['horizontal', 'vertical']):
             for label in ax.get_xticklabels():
                 label.set_rotation(rot)
-        except:
+        else:
             raise Exception('Unknown rot argument!')
     elif axis == 'y':
-        try:
+        if (type(rot) == int) or (rot in ['horizontal', 'vertical']):
             for label in ax.get_yticklabels():
                 label.set_rotation(rot)
-        except:
+        else:
             raise Exception('Unknown rot argument!')
     else:
         raise Exception('Unsupported axis!')


### PR DESCRIPTION
… argument