### PR TITLE
update unit test rot

### DIFF
--- a/grplot/features/rot/rot_def.py
+++ b/grplot/features/rot/rot_def.py
@@ -1,16 +1,20 @@
+import matplotlib.text as mpl_text
+
+
 def rot_def(ax, axis, rot):
+    labels: mpl_text.Text= None
+
     if axis == 'x':
-        try:
-            for label in ax.get_xticklabels():
-                label.set_rotation(rot)
-        except:
-            raise Exception('Unknown rot argument!')
+        labels = ax.get_xticklabels()
     elif axis == 'y':
-        try:
-            for label in ax.get_yticklabels():
-                label.set_rotation(rot)
-        except:
-            raise Exception('Unknown rot argument!')
+        labels = ax.get_yticklabels()
     else:
         raise Exception('Unsupported axis!')
+
+    try:
+        for label in labels:
+            label.set_rotation(rot)
+    except Exception:
+        raise Exception('Unknown rot argument!')
+
     return ax

--- a/tests/features/lim/test_lim_type.py
+++ b/tests/features/lim/test_lim_type.py
@@ -36,3 +36,4 @@ def test_lim_type(_ax, input, expected):
             lim_type(_ax, *input)
     else:
         assert ax.get_xticks()[-1] == expected
+

--- a/tests/features/rot/conftest.py
+++ b/tests/features/rot/conftest.py
@@ -9,4 +9,5 @@ def _ax():
 
     ax = plt.subplot(221)
     ax.plot(x,y)
-    return ax
+    yield ax
+    plt.close()

--- a/tests/features/rot/test_rot_def.py
+++ b/tests/features/rot/test_rot_def.py
@@ -1,22 +1,34 @@
 from grplot.features.rot.rot_def import rot_def
-import matplotlib as mpl
 import pytest
 
-@pytest.mark.parametrize('input', [
-    ({ 'axis': 'x', 'rot': 90}),
-    ({ 'axis': 'y', 'rot': 90}),
-    ({ 'axis': None, 'rot': 90}),
-])
-def test_rot_def(_ax: any, input: dict):
-    try:
-        rotated_tick_ax = rot_def(_ax, **input)
-    except:
-        with pytest.raises(Exception):
-            rot_def(_ax, *input)
-    else:
-        if input['axis'] == 'x':
-            for label in rotated_tick_ax.get_xticklabels():
-                assert label.get_rotation() == input['rot']
-        else:
-            for label in rotated_tick_ax.get_yticklabels():
-                assert label.get_rotation() == input['rot']
+
+class TestRotDef:
+    def test_x_rot(self, _ax):
+        rotated_tick_ax = rot_def(
+            ax=_ax,
+            axis='x',
+            rot=90
+        )
+
+        for label in rotated_tick_ax.get_xticklabels():
+            assert label.get_rotation() == 90
+
+    def test_y_rot(self, _ax):
+        rotated_tick_ax = rot_def(
+            ax=_ax,
+            axis='y',
+            rot=90
+        )
+
+        for label in rotated_tick_ax.get_yticklabels():
+            assert label.get_rotation() == 90
+
+    def test_unsupported_axis(self, _ax):
+        with pytest.raises(Exception) as exc_info:
+            rot_def(
+                ax=_ax,
+                axis='ok',
+                rot=90
+            )
+
+        assert str(exc_info.value) == 'Unsupported axis!'

--- a/tests/features/rot/test_rot_type.py
+++ b/tests/features/rot/test_rot_type.py
@@ -1,19 +1,40 @@
 from grplot.features.rot.rot_type import rot_type
-from grplot.utils.arg_axis_ax_type import arg_axis_ax_type
 import pytest
 
-@pytest.mark.parametrize('input,expected', [
-    ([None, None, None, None], 90),
-    (['x', 90, None, None], 90),
-    (['x', 'hola', None, None], None)
-])
-def test_rot_type(_ax: any, input: list, expected: any):
-    try:
-        rotated_ax = rot_type(_ax, *input)
-    except:
-        with pytest.raises(Exception):
-            rot_type(_ax, *input)
-    else:
+
+class TestRotType:
+    def test_rot_is_none(self, _ax):
+        rotated_ax = rot_type(
+            ax=_ax,
+            axes=None,
+            axis='x',
+            axislabel='x',
+            rot=None
+        )
+
         for label in rotated_ax.get_xticklabels():
-            assert label.get_rotation() == expected
-    
+            assert label.get_rotation() == 0
+
+    def test_rot_has_value(self, _ax):
+        rotated_ax = rot_type(
+            ax=_ax,
+            axes=None,
+            axis='x',
+            axislabel='x',
+            rot=90
+        )
+
+        for label in rotated_ax.get_xticklabels():
+            assert label.get_rotation() == 90
+
+    def test_unknown_rot_argument(self, _ax):
+        with pytest.raises(Exception) as exc_info:
+            rot_type(
+                ax=_ax,
+                axes=None,
+                axis='x',
+                axislabel='x',
+                rot='keliling'
+            )
+
+        assert str(exc_info.value) == 'Unknown rot argument!'


### PR DESCRIPTION
@ghiffaryr coba di run dlu unit testnya versi `matplotlib` gw itu `set_rotation`nya isinya ini
```python
   def set_rotation(self, s):
        """
        Set the rotation of the text.

        Parameters
        ----------
        s : float or {'vertical', 'horizontal'}
            The rotation angle in degrees in mathematically positive direction
            (counterclockwise). 'horizontal' equals 0, 'vertical' equals 90.
        """
        self._rotation = s
        self.stale = True
```

kalo versi terbaru itu ini
```python
def set_rotation(self, s):
        """
        Set the rotation of the text.
        Parameters
        ----------
        s : float or {'vertical', 'horizontal'}
            The rotation angle in degrees in mathematically positive direction
            (counterclockwise). 'horizontal' equals 0, 'vertical' equals 90.
        """
        if isinstance(s, Real):
            self._rotation = float(s) % 360
        elif cbook._str_equal(s, 'horizontal') or s is None:
            self._rotation = 0.
        elif cbook._str_equal(s, 'vertical'):
            self._rotation = 90.
        else:
            raise ValueError("rotation must be 'vertical', 'horizontal' or "
                             f"a number, not {s}")
        self.stale = True
```

jadinya yang ditempat gw ada test case yang failed